### PR TITLE
fix crash when running stats in html mode and update chart label

### DIFF
--- a/pkg/chart.go
+++ b/pkg/chart.go
@@ -75,12 +75,12 @@ func NewChart(stats Stats, year int, filename string) error {
 
 	articleReadCount := []int{}
 
-	totalReadTime := []float32{}
+	totalReadTime := make([]float32, 12)
 
 	for idx := 1; idx <= 12; idx++ {
 		finBooks := stats.BooksFinishedMonth(year, idx)
 		for jdx := range finBooks {
-			totalReadTime = append(totalReadTime, float32(finBooks[jdx].ReadSeconds()))
+			totalReadTime[idx-1] += float32(finBooks[jdx].ReadSeconds())
 
 			data.BooksFinished = append(data.BooksFinished, chartTemplateStat{
 				Title:    finBooks[jdx].Title,
@@ -105,6 +105,7 @@ func NewChart(stats Stats, year int, filename string) error {
 		}
 
 		bookReadCount = append(bookReadCount, len(stats.BooksFinishedMonth(year, idx)))
+
 		articleReadCount = append(articleReadCount, len(stats.ArticlesFinishedMonth(year, idx)))
 	}
 

--- a/pkg/files/template.html
+++ b/pkg/files/template.html
@@ -175,7 +175,7 @@
                 <!--Graph Card-->
                 <div class="bg-white border rounded shadow">
                     <div class="border-b p-3">
-                        <h5 class="font-bold text-gray-600">Seconds Reading</h5>
+                        <h5 class="font-bold text-gray-600">Seconds Reading (Finished Books & Articles)</h5>
                     </div>
                     <div class="p-5">
                         <canvas id="chartjs-0" class="chartjs" width="undefined" height="undefined"></canvas>


### PR DESCRIPTION
Kobo Libra Model N428

- prevents a crash due to a runtime error when running the `stats` command in html mode. The error occurred when generating stats for the year 2025, which had no data before april.

- updates the chart label from "Seconds Reading" to "Seconds Reading (Finished Books & Articles)" for clarity.